### PR TITLE
fix(api): replace async_get_device_info with async_get_sys_attr_info

### DIFF
--- a/custom_components/zowietek/api.py
+++ b/custom_components/zowietek/api.py
@@ -279,18 +279,6 @@ class ZowietekClient:
         )
         return self._extract_data(data, "data")
 
-    async def async_get_device_info(self) -> dict[str, Any]:
-        """Get device information from the device.
-
-        Returns:
-            Device information including serial number, name, and firmware version.
-        """
-        data = await self._request(
-            "/system?option=getinfo",
-            {"group": "devinfo"},
-        )
-        return self._extract_data(data, "data")
-
     async def async_get_video_info(self) -> dict[str, Any]:
         """Get comprehensive video information from the device.
 

--- a/custom_components/zowietek/entity.py
+++ b/custom_components/zowietek/entity.py
@@ -50,20 +50,17 @@ class ZowietekEntity(CoordinatorEntity[ZowietekCoordinator]):
             DeviceInfo containing manufacturer, model, name, firmware version,
             serial number, and a link to the device's web UI.
         """
-        # Get firmware version from system data
-        sw_version = self.coordinator.data.system.get("firmware_version")
-        if sw_version is not None:
-            sw_version = str(sw_version)
+        # Get firmware version from system data (treat empty string as None)
+        sw_version_raw = self.coordinator.data.system.get("firmware_version")
+        sw_version = str(sw_version_raw) if sw_version_raw else None
 
-        # Get serial number from system data
-        serial_number = self.coordinator.data.system.get("devicesn")
-        if serial_number is not None:
-            serial_number = str(serial_number)
+        # Get serial number from system data (treat empty string as None)
+        serial_number_raw = self.coordinator.data.system.get("devicesn")
+        serial_number = str(serial_number_raw) if serial_number_raw else None
 
-        # Get hardware version for hw_version field
-        hw_version = self.coordinator.data.system.get("hardware_version")
-        if hw_version is not None:
-            hw_version = str(hw_version)
+        # Get hardware version for hw_version field (treat empty string as None)
+        hw_version_raw = self.coordinator.data.system.get("hardware_version")
+        hw_version = str(hw_version_raw) if hw_version_raw else None
 
         return DeviceInfo(
             identifiers={(DOMAIN, str(self.coordinator.config_entry.unique_id))},

--- a/custom_components/zowietek/models.py
+++ b/custom_components/zowietek/models.py
@@ -98,22 +98,6 @@ class ZowietekNetworkInfo(TypedDict):
     mac_address: NotRequired[str]
 
 
-class ZowietekDeviceInfo(TypedDict):
-    """Device information from async_get_device_info API.
-
-    Contains device identification and version information as returned
-    by the actual ZowieBox API endpoint.
-    """
-
-    status: NotRequired[str]
-    rsp: NotRequired[str]
-    devicesn: NotRequired[str]
-    devicename: NotRequired[str]
-    softver: NotRequired[str]
-    hardver: NotRequired[str]
-    mac: NotRequired[str]
-
-
 class ZowietekVideoData(TypedDict):
     """Video information from async_get_video_info API.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -881,3 +881,39 @@ A typical control flow for a custom app might look like:
 6. Enable NDI if needed via `ndi` group
 7. Manage recording and snapshots via `/storage` / snapshot APIs
 8. Persist user accounts, time, and network settings via `/system`, `/lan`, `/wifi`, `/ap`, `/port`, `/mdns`
+
+---
+
+## 29. System Attributes – /system, group: "sys_attr"
+
+The `sys_attr` group provides comprehensive device identification information.
+
+### 29.1 Get system attributes
+
+- **Endpoint:** `POST /system?option=getinfo&login_check_flag=1`
+- **Body:**
+
+```json
+{ "group": "sys_attr" }
+```
+
+- **Response data:**
+  - `SN` – Device serial number
+  - `device_name` – Device name (e.g., "ZowieBox-27117")
+  - `firmware_version` – Firmware version (e.g., "2.0.0.12")
+  - `hardware_version` – Hardware version (e.g., "3.1.12.22")
+  - `manufacturer` – Manufacturer name ("Zowietek")
+  - `model` – Device model ("ZowieBox")
+  - `language_id` – Current language setting
+  - `isp_version` – ISP version
+  - `mcu_version` – MCU version
+  - `web_version` – Web interface version
+  - `ndi_version` – NDI library version
+  - `app_version` – Application version
+  - `ndi_activate` – NDI activation status
+  - `ndi_switch` – NDI enabled status
+  - `chipid` – Hardware chip ID
+  - `first_use_flag` – First use indicator
+  - `ui_first_use_flag` – UI first use indicator
+
+**Note:** This is the preferred endpoint for device identification. The `devinfo` group is NOT supported by ZowieBox devices and will return "Invalid parameters: param group not support !!!"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -352,66 +352,6 @@ class TestZowietekClientSystemTime:
         assert result["time"]["year"] == 2025
 
 
-class TestZowietekClientDeviceInfo:
-    """Tests for ZowietekClient device info endpoint."""
-
-    @pytest.mark.asyncio
-    async def test_async_get_device_info_success(self) -> None:
-        """Test successful device info retrieval."""
-        mock_response = _create_mock_response(
-            {
-                "status": STATUS_SUCCESS,
-                "rsp": "succeed",
-                "data": {
-                    "devicesn": "ZBOX-ABC123",
-                    "devicename": "ZowieBox-Office",
-                    "softver": "1.2.3",
-                    "hardver": "2.0",
-                    "mac": "00:11:22:33:44:55",
-                },
-            }
-        )
-        mock_session = _create_mock_session(mock_response)
-
-        client = ZowietekClient(
-            host="192.168.1.100",
-            username="admin",
-            password="admin",
-            session=mock_session,
-        )
-
-        result = await client.async_get_device_info()
-
-        assert result["devicesn"] == "ZBOX-ABC123"
-        assert result["devicename"] == "ZowieBox-Office"
-        assert result["softver"] == "1.2.3"
-
-    @pytest.mark.asyncio
-    async def test_async_get_device_info_fallback_without_data_key(self) -> None:
-        """Test device info retrieval when data key is missing (returns full response)."""
-        mock_response = _create_mock_response(
-            {
-                "status": STATUS_SUCCESS,
-                "rsp": "succeed",
-                "devicesn": "ZBOX-ABC123",  # Data at root level, no "data" key
-            }
-        )
-        mock_session = _create_mock_session(mock_response)
-
-        client = ZowietekClient(
-            host="192.168.1.100",
-            username="admin",
-            password="admin",
-            session=mock_session,
-        )
-
-        result = await client.async_get_device_info()
-
-        # Falls back to returning the full response when "data" key is missing
-        assert result["status"] == STATUS_SUCCESS
-        assert result["devicesn"] == "ZBOX-ABC123"
-
-
 class TestZowietekClientVideoInfo:
     """Tests for ZowietekClient video info endpoint."""
 

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -176,7 +176,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -39,11 +39,12 @@ def mock_client_success() -> Generator[MagicMock]:
         client.host = "http://192.168.1.100"
         client.async_test_connection = AsyncMock(return_value=True)
         client.async_validate_credentials = AsyncMock(return_value=True)
-        client.async_get_device_info = AsyncMock(
+        # Use async_get_sys_attr_info instead of async_get_device_info (#49)
+        client.async_get_sys_attr_info = AsyncMock(
             return_value={
-                "devicesn": "ZBOX-ABC123",
-                "devicename": "ZowieBox-Office",
-                "softver": "1.2.3",
+                "SN": "ZBOX-ABC123",
+                "device_name": "ZowieBox-Office",
+                "firmware_version": "1.2.3",
             }
         )
         client.close = AsyncMock()
@@ -376,8 +377,8 @@ async def test_config_flow_device_info_fallback(
         client.host = "http://192.168.1.100"
         client.async_test_connection = AsyncMock(return_value=True)
         client.async_validate_credentials = AsyncMock(return_value=True)
-        # Device info endpoint not supported - should fall back gracefully
-        client.async_get_device_info = AsyncMock(
+        # Sys attr endpoint not supported - should fall back gracefully (#49)
+        client.async_get_sys_attr_info = AsyncMock(
             side_effect=ZowietekApiError("Invalid parameters", "00003")
         )
         client.close = AsyncMock()
@@ -404,11 +405,11 @@ async def test_config_flow_device_info_fallback(
         assert result["result"].unique_id == "http://192.168.1.100"
 
 
-async def test_config_flow_device_info_fallback_with_hostname(
+async def test_config_flow_sys_attr_fallback_with_hostname(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
 ) -> None:
-    """Test config flow derives name from hostname when device info unavailable."""
+    """Test config flow derives name from hostname when sys attr unavailable."""
     from custom_components.zowietek.exceptions import ZowietekApiError
 
     with patch(
@@ -419,7 +420,8 @@ async def test_config_flow_device_info_fallback_with_hostname(
         client.host = "http://zow001.example.com"
         client.async_test_connection = AsyncMock(return_value=True)
         client.async_validate_credentials = AsyncMock(return_value=True)
-        client.async_get_device_info = AsyncMock(
+        # Sys attr endpoint not supported - should fall back gracefully (#49)
+        client.async_get_sys_attr_info = AsyncMock(
             side_effect=ZowietekApiError("Invalid parameters", "00003")
         )
         client.close = AsyncMock()
@@ -495,8 +497,8 @@ async def test_config_flow_host_with_scheme_and_port(
         client.host = "http://192.168.1.100:8080"
         client.async_test_connection = AsyncMock(return_value=True)
         client.async_validate_credentials = AsyncMock(return_value=True)
-        # Device info unavailable - tests _derive_name_from_host
-        client.async_get_device_info = AsyncMock(
+        # Sys attr unavailable - tests _derive_name_from_host (#49)
+        client.async_get_sys_attr_info = AsyncMock(
             side_effect=ZowietekApiError("Invalid parameters", "00003")
         )
         client.close = AsyncMock()
@@ -537,8 +539,8 @@ async def test_config_flow_host_with_port_and_subdomain(
         client.host = "http://zow001.local:8080"
         client.async_test_connection = AsyncMock(return_value=True)
         client.async_validate_credentials = AsyncMock(return_value=True)
-        # Device info unavailable - tests _derive_name_from_host
-        client.async_get_device_info = AsyncMock(
+        # Sys attr unavailable - tests _derive_name_from_host (#49)
+        client.async_get_sys_attr_info = AsyncMock(
             side_effect=ZowietekApiError("Invalid parameters", "00003")
         )
         client.close = AsyncMock()
@@ -580,8 +582,8 @@ async def test_config_flow_empty_hostname_fallback(
         client.host = "http://....:8080"
         client.async_test_connection = AsyncMock(return_value=True)
         client.async_validate_credentials = AsyncMock(return_value=True)
-        # Device info unavailable - tests _derive_name_from_host fallback
-        client.async_get_device_info = AsyncMock(
+        # Sys attr unavailable - tests _derive_name_from_host fallback (#49)
+        client.async_get_sys_attr_info = AsyncMock(
             side_effect=ZowietekApiError("Invalid parameters", "00003")
         )
         client.close = AsyncMock()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -165,7 +165,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)
@@ -346,12 +345,11 @@ class TestZowietekEntityDeviceInfo:
         mock_config_entry.add_to_hass(hass)
 
         # Device info without model field
-        mock_zowietek_client.async_get_device_info.return_value = {
-            "status": "00000",
-            "rsp": "succeed",
-            "devicesn": "zowiebox-test-12345",
-            "devicename": "ZowieBox-Test",
-            "softver": "1.0.0",
+        # sys_attr response without model field - should fall back to "ZowieBox"
+        mock_zowietek_client.async_get_sys_attr_info.return_value = {
+            "SN": "zowiebox-test-12345",
+            "device_name": "ZowieBox-Test",
+            "firmware_version": "1.0.0",
         }
 
         coordinator = ZowietekCoordinator(hass, mock_config_entry)
@@ -438,11 +436,10 @@ class TestZowietekEntityDeviceInfo:
         mock_config_entry.add_to_hass(hass)
 
         # Device info without softver
-        mock_zowietek_client.async_get_device_info.return_value = {
-            "status": "00000",
-            "rsp": "succeed",
-            "devicesn": "zowiebox-test-12345",
-            "devicename": "ZowieBox-Test",
+        # sys_attr response without firmware_version - sw_version should be None
+        mock_zowietek_client.async_get_sys_attr_info.return_value = {
+            "SN": "zowiebox-test-12345",
+            "device_name": "ZowieBox-Test",
         }
 
         coordinator = ZowietekCoordinator(hass, mock_config_entry)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -170,7 +170,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -229,7 +229,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -227,7 +227,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -191,7 +191,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -190,7 +190,6 @@ def mock_zowietek_client(
         "custom_components.zowietek.coordinator.ZowietekClient", autospec=True
     ) as mock_client_class:
         client = mock_client_class.return_value
-        client.async_get_device_info = AsyncMock(return_value=mock_device_info)
         client.async_get_video_info = AsyncMock(return_value=mock_video_info)
         client.async_get_input_signal = AsyncMock(return_value=mock_input_signal)
         client.async_get_output_info = AsyncMock(return_value=mock_output_info)


### PR DESCRIPTION
## Summary

- **Fixes #49**: The `async_get_device_info` method used the 'devinfo' group which is not supported by ZowieBox devices
- Updated config flow to use `async_get_sys_attr_info` which returns device identification data
- Removed dead code (`async_get_device_info` method and `ZowietekDeviceInfo` TypedDict)
- Updated entity.py to handle empty strings as None for optional device info fields
- Added `sys_attr` group documentation to docs/api.md

## Test plan

- [x] Unit tests updated and passing (508 tests, 100% coverage)
- [x] Tested against live ZowieBox device - sys_attr endpoint returns correct data
- [x] Tested in dev Home Assistant instance - device registry shows correct info:
  - Name: ZowieBox-27117
  - Manufacturer: Zowietek
  - Model: ZowieBox
  - SW Version: 2.0.0.12
  - HW Version: 3.1.12.22
  - Serial Number: nnnnnn

🤖 Generated with [Claude Code](https://claude.com/claude-code)