### PR TITLE
feat(discovery): implement proprietary UDP multicast device discovery

### DIFF
--- a/custom_components/zowietek/discovery.py
+++ b/custom_components/zowietek/discovery.py
@@ -1,0 +1,242 @@
+"""ZowieBox device discovery via UDP multicast.
+
+ZowieBox devices use a proprietary UDP multicast discovery protocol:
+- Multicast Address: 224.170.1.242
+- Port: 21007
+- Protocol: JSON over UDP (IPv4 only)
+
+Message Types:
+- check_devices_request: Discovery request
+- check_devices_result: Discovery response with device info
+- keepalive: Periodic heartbeat (ignored)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import socket
+import struct
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+_LOGGER = logging.getLogger(__name__)
+
+# Discovery protocol constants
+MULTICAST_GROUP = "224.170.1.242"
+DISCOVERY_PORT = 21007
+
+# Default timeout for discovery (seconds)
+DEFAULT_DISCOVERY_TIMEOUT = 3.0
+
+# Discovery request identifier
+DISCOVERY_REQUEST_SN = "ha-zowietek"
+
+
+@dataclass
+class DiscoveredDevice:
+    """Represents a discovered ZowieBox device.
+
+    Attributes:
+        ip: Device IP address.
+        web_port: HTTP API port (usually 80).
+        device_sn: Device serial number (unique identifier).
+        device_name: User-configured device name.
+        product_id: Product type identifier.
+        workmode_id: Current operating mode.
+    """
+
+    ip: str
+    web_port: int
+    device_sn: str
+    device_name: str
+    product_id: int
+    workmode_id: int
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str | int]) -> DiscoveredDevice:
+        """Create a DiscoveredDevice from a dictionary.
+
+        Args:
+            data: Dictionary containing device data from discovery response.
+
+        Returns:
+            A DiscoveredDevice instance.
+        """
+        return cls(
+            ip=str(data.get("ip", "")),
+            web_port=int(data.get("web_port", 80)),
+            device_sn=str(data.get("device_sn", "")),
+            device_name=str(data.get("device_name", "")),
+            product_id=int(data.get("product_id", 0)),
+            workmode_id=int(data.get("workmode_id", 0)),
+        )
+
+    @property
+    def host(self) -> str:
+        """Return the HTTP host URL for this device.
+
+        Returns:
+            URL string in format http://ip:port
+        """
+        return f"http://{self.ip}:{self.web_port}"
+
+
+class ZowietekDiscovery:
+    """Discover ZowieBox devices on the local network via UDP multicast.
+
+    This class implements the ZowieBox proprietary discovery protocol
+    which uses JSON messages over UDP multicast on 224.170.1.242:21007.
+
+    Example:
+        discovery = ZowietekDiscovery(timeout=5.0)
+        devices = await discovery.async_discover()
+        for device in devices:
+            print(f"Found: {device.device_name} at {device.ip}")
+    """
+
+    def __init__(self, timeout: float = DEFAULT_DISCOVERY_TIMEOUT) -> None:
+        """Initialize the discovery instance.
+
+        Args:
+            timeout: How long to wait for responses (seconds).
+        """
+        self.timeout = timeout
+
+    def _build_discovery_request(self) -> bytes:
+        """Build the discovery request message.
+
+        Returns:
+            JSON-encoded discovery request as bytes.
+        """
+        request = {
+            "opt": "check_devices_request",
+            "master_device_sn": DISCOVERY_REQUEST_SN,
+        }
+        return json.dumps(request).encode("utf-8")
+
+    def _parse_response(self, data: bytes) -> DiscoveredDevice | None:
+        """Parse a discovery response message.
+
+        Args:
+            data: Raw bytes received from the socket.
+
+        Returns:
+            DiscoveredDevice if valid response, None otherwise.
+        """
+        try:
+            message = json.loads(data.decode("utf-8"))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            _LOGGER.debug("Invalid discovery response: not valid JSON")
+            return None
+
+        # Only process check_devices_result messages
+        opt = message.get("opt")
+        if opt != "check_devices_result":
+            if opt == "keepalive":
+                _LOGGER.debug("Ignoring keepalive from device")
+            else:
+                _LOGGER.debug("Ignoring message with opt=%s", opt)
+            return None
+
+        # Extract device data
+        device_data = message.get("data")
+        if not isinstance(device_data, dict):
+            _LOGGER.debug("Discovery response missing data field")
+            return None
+
+        try:
+            return DiscoveredDevice.from_dict(device_data)
+        except (KeyError, ValueError, TypeError) as err:
+            _LOGGER.debug("Failed to parse device data: %s", err)
+            return None
+
+    async def async_discover(self) -> list[DiscoveredDevice]:
+        """Discover ZowieBox devices on the network.
+
+        Sends a discovery request to the multicast group and collects
+        responses until the timeout expires.
+
+        Returns:
+            List of discovered devices (deduplicated by serial number).
+
+        Raises:
+            OSError: If there's a network error (socket creation, etc).
+        """
+        devices: dict[str, DiscoveredDevice] = {}
+        sock: socket.socket | None = None
+
+        try:
+            # Create UDP socket
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+            sock.setblocking(False)
+
+            # Join multicast group to receive responses
+            mreq = struct.pack("4sl", socket.inet_aton(MULTICAST_GROUP), socket.INADDR_ANY)
+            sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+
+            # Bind to receive responses on the discovery port
+            sock.bind(("", DISCOVERY_PORT))
+
+            # Send discovery request
+            request = self._build_discovery_request()
+            sock.sendto(request, (MULTICAST_GROUP, DISCOVERY_PORT))
+            _LOGGER.debug("Sent discovery request to %s:%s", MULTICAST_GROUP, DISCOVERY_PORT)
+
+            # Collect responses until timeout
+            loop = asyncio.get_event_loop()
+            end_time = loop.time() + self.timeout
+
+            while loop.time() < end_time:
+                remaining = end_time - loop.time()
+                if remaining <= 0:
+                    break
+
+                try:
+                    # Use asyncio to wait for data with timeout
+                    data, addr = await asyncio.wait_for(
+                        loop.sock_recvfrom(sock, 4096),
+                        timeout=min(remaining, 0.5),
+                    )
+                    _LOGGER.debug("Received response from %s", addr)
+
+                    device = self._parse_response(data)
+                    if device and device.device_sn and device.device_sn not in devices:
+                        # Deduplicate by serial number
+                        devices[device.device_sn] = device
+                        _LOGGER.debug(
+                            "Discovered device: %s (%s)",
+                            device.device_name,
+                            device.ip,
+                        )
+                except TimeoutError:
+                    # No response within the interval, continue waiting
+                    continue
+
+        finally:
+            if sock is not None:
+                sock.close()
+
+        _LOGGER.info("Discovery complete: found %d device(s)", len(devices))
+        return list(devices.values())
+
+
+async def async_discover_devices(
+    timeout: float = DEFAULT_DISCOVERY_TIMEOUT,
+) -> list[DiscoveredDevice]:
+    """Convenience function to discover ZowieBox devices.
+
+    Args:
+        timeout: How long to wait for responses (seconds).
+
+    Returns:
+        List of discovered devices.
+    """
+    discovery = ZowietekDiscovery(timeout=timeout)
+    return await discovery.async_discover()

--- a/custom_components/zowietek/strings.json
+++ b/custom_components/zowietek/strings.json
@@ -3,6 +3,16 @@
     "step": {
       "user": {
         "title": "Add ZowieBox Device",
+        "description": "Select a discovered device or choose to enter the address manually.",
+        "data": {
+          "device": "Device"
+        },
+        "data_description": {
+          "device": "Select a ZowieBox device from the list"
+        }
+      },
+      "manual": {
+        "title": "Add ZowieBox Device",
         "description": "Enter the connection details for your ZowieBox device.",
         "data": {
           "host": "Host",
@@ -11,6 +21,18 @@
         },
         "data_description": {
           "host": "Hostname, IP address, or URL of the ZowieBox device",
+          "username": "Device username (default: admin)",
+          "password": "Device password (default: admin)"
+        }
+      },
+      "credentials": {
+        "title": "Enter Credentials",
+        "description": "Enter credentials for {device_name} at {device_ip}.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "data_description": {
           "username": "Device username (default: admin)",
           "password": "Device password (default: admin)"
         }

--- a/custom_components/zowietek/translations/en.json
+++ b/custom_components/zowietek/translations/en.json
@@ -3,6 +3,16 @@
     "step": {
       "user": {
         "title": "Add ZowieBox Device",
+        "description": "Select a discovered device or choose to enter the address manually.",
+        "data": {
+          "device": "Device"
+        },
+        "data_description": {
+          "device": "Select a ZowieBox device from the list"
+        }
+      },
+      "manual": {
+        "title": "Add ZowieBox Device",
         "description": "Enter the connection details for your ZowieBox device.",
         "data": {
           "host": "Host",
@@ -11,6 +21,18 @@
         },
         "data_description": {
           "host": "Hostname, IP address, or URL of the ZowieBox device",
+          "username": "Device username (default: admin)",
+          "password": "Device password (default: admin)"
+        }
+      },
+      "credentials": {
+        "title": "Enter Credentials",
+        "description": "Enter credentials for {device_name} at {device_ip}.",
+        "data": {
+          "username": "Username",
+          "password": "Password"
+        },
+        "data_description": {
           "username": "Device username (default: admin)",
           "password": "Device password (default: admin)"
         }

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,9 +12,15 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.zowietek.const import DOMAIN
+from custom_components.zowietek.discovery import DiscoveredDevice
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
 
 
 @pytest.fixture
@@ -26,6 +32,72 @@ def mock_setup_entry() -> Generator[AsyncMock]:
         create=True,
     ) as mock_setup:
         yield mock_setup
+
+
+@pytest.fixture
+def mock_discovery_no_devices() -> Generator[AsyncMock]:
+    """Mock discovery returning no devices."""
+    with patch(
+        "custom_components.zowietek.config_flow.async_discover_devices",
+        return_value=[],
+    ) as mock_discover:
+        yield mock_discover
+
+
+@pytest.fixture
+def mock_discovery_one_device() -> Generator[AsyncMock]:
+    """Mock discovery returning one device."""
+    device = DiscoveredDevice(
+        ip="192.168.1.100",
+        web_port=80,
+        device_sn="ZBOX-ABC123",
+        device_name="ZowieBox-Office",
+        product_id=2,
+        workmode_id=1,
+    )
+    with patch(
+        "custom_components.zowietek.config_flow.async_discover_devices",
+        return_value=[device],
+    ) as mock_discover:
+        yield mock_discover
+
+
+@pytest.fixture
+def mock_discovery_multiple_devices() -> Generator[AsyncMock]:
+    """Mock discovery returning multiple devices."""
+    devices = [
+        DiscoveredDevice(
+            ip="192.168.1.100",
+            web_port=80,
+            device_sn="ZBOX-ABC123",
+            device_name="ZowieBox-Office",
+            product_id=2,
+            workmode_id=1,
+        ),
+        DiscoveredDevice(
+            ip="192.168.1.101",
+            web_port=80,
+            device_sn="ZBOX-DEF456",
+            device_name="ZowieBox-Studio",
+            product_id=2,
+            workmode_id=1,
+        ),
+    ]
+    with patch(
+        "custom_components.zowietek.config_flow.async_discover_devices",
+        return_value=devices,
+    ) as mock_discover:
+        yield mock_discover
+
+
+@pytest.fixture
+def mock_discovery_error() -> Generator[AsyncMock]:
+    """Mock discovery raising an error."""
+    with patch(
+        "custom_components.zowietek.config_flow.async_discover_devices",
+        side_effect=OSError("Network error"),
+    ) as mock_discover:
+        yield mock_discover
 
 
 @pytest.fixture
@@ -53,8 +125,16 @@ def mock_client_success() -> Generator[MagicMock]:
         yield mock_client_class
 
 
-async def test_user_form_shown(hass: HomeAssistant) -> None:
-    """Test that the user form is shown on initial step."""
+# =============================================================================
+# User Step Tests - Device Picker
+# =============================================================================
+
+
+async def test_user_form_shown_with_discovered_devices(
+    hass: HomeAssistant,
+    mock_discovery_one_device: AsyncMock,
+) -> None:
+    """Test that the user form shows device picker when devices are discovered."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -62,22 +142,109 @@ async def test_user_form_shown(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
+    # Note: errors key may not be present when no errors occurred
+    assert result.get("errors") in (None, {})
+
+
+async def test_user_form_shown_no_devices(
+    hass: HomeAssistant,
+    mock_discovery_no_devices: AsyncMock,
+) -> None:
+    """Test that the manual form is shown when no devices are discovered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # When no devices found, skip directly to manual entry
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
     assert result["errors"] == {}
 
 
-async def test_successful_config_flow(
+async def test_user_form_shown_on_discovery_error(
     hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_client_success: MagicMock,
+    mock_discovery_error: AsyncMock,
 ) -> None:
-    """Test successful config flow creates entry."""
+    """Test that the manual form is shown when discovery fails."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # When discovery fails, go directly to manual entry
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+
+async def test_user_selects_manual_entry(
+    hass: HomeAssistant,
+    mock_discovery_one_device: AsyncMock,
+) -> None:
+    """Test user selecting manual entry redirects to manual step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
     )
 
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
 
+    # Select manual entry option
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"device": "manual"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+
+async def test_user_selects_discovered_device(
+    hass: HomeAssistant,
+    mock_discovery_one_device: AsyncMock,
+) -> None:
+    """Test user selecting a discovered device redirects to credentials step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    # Select the discovered device
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"device": "ZBOX-ABC123"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+
+# =============================================================================
+# Manual Entry Flow Tests
+# =============================================================================
+
+
+async def test_successful_manual_config_flow(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovery_no_devices: AsyncMock,
+    mock_client_success: MagicMock,
+) -> None:
+    """Test successful manual config flow creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # No devices found, goes directly to manual entry
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual"
+
+    # Submit manual entry form
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
@@ -98,10 +265,11 @@ async def test_successful_config_flow(
     assert result["result"].unique_id == "ZBOX-ABC123"
 
 
-async def test_config_flow_connection_error(
+async def test_manual_config_flow_connection_error(
     hass: HomeAssistant,
+    mock_discovery_no_devices: AsyncMock,
 ) -> None:
-    """Test config flow handles connection error."""
+    """Test manual config flow handles connection error."""
     from custom_components.zowietek.exceptions import ZowietekConnectionError
 
     with patch(
@@ -121,6 +289,9 @@ async def test_config_flow_connection_error(
             context={"source": SOURCE_USER},
         )
 
+        # No devices found, goes directly to manual entry
+        assert result["step_id"] == "manual"
+
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -131,13 +302,357 @@ async def test_config_flow_connection_error(
         )
 
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "manual"
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_config_flow_auth_error(
+async def test_manual_config_flow_auth_error(
     hass: HomeAssistant,
+    mock_discovery_no_devices: AsyncMock,
 ) -> None:
-    """Test config flow handles authentication error."""
+    """Test manual config flow handles authentication error."""
+    from custom_components.zowietek.exceptions import ZowietekAuthError
+
+    with patch(
+        "custom_components.zowietek.config_flow.ZowietekClient",
+        autospec=True,
+    ) as mock_client_class:
+        client = mock_client_class.return_value
+        client.async_test_connection = AsyncMock(return_value=True)
+        client.async_validate_credentials = AsyncMock(
+            side_effect=ZowietekAuthError("Invalid credentials")
+        )
+        client.close = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        # No devices found, goes directly to manual entry
+        assert result["step_id"] == "manual"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "wrong_password",
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "manual"
+        assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_manual_config_flow_timeout_error(
+    hass: HomeAssistant,
+    mock_discovery_no_devices: AsyncMock,
+) -> None:
+    """Test manual config flow handles timeout error."""
+    from custom_components.zowietek.exceptions import ZowietekTimeoutError
+
+    with patch(
+        "custom_components.zowietek.config_flow.ZowietekClient",
+        autospec=True,
+    ) as mock_client_class:
+        client = mock_client_class.return_value
+        client.async_test_connection = AsyncMock(
+            side_effect=ZowietekTimeoutError("Timeout after 10s")
+        )
+        client.close = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        # No devices found, goes directly to manual entry
+        assert result["step_id"] == "manual"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "admin",
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "manual"
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_manual_config_flow_unknown_error(
+    hass: HomeAssistant,
+    mock_discovery_no_devices: AsyncMock,
+) -> None:
+    """Test manual config flow handles unknown error."""
+    with patch(
+        "custom_components.zowietek.config_flow.ZowietekClient",
+        autospec=True,
+    ) as mock_client_class:
+        client = mock_client_class.return_value
+        client.async_test_connection = AsyncMock(side_effect=RuntimeError("Unknown"))
+        client.close = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        # No devices found, goes directly to manual entry
+        assert result["step_id"] == "manual"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "admin",
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "manual"
+        assert result["errors"] == {"base": "unknown"}
+
+
+async def test_manual_config_flow_duplicate_device(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovery_no_devices: AsyncMock,
+    mock_client_success: MagicMock,
+) -> None:
+    """Test manual config flow aborts if device already configured."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ZBOX-ABC123",
+        data={
+            CONF_HOST: "192.168.1.50",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin",
+        },
+    )
+    existing_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # No devices found, goes directly to manual entry
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "192.168.1.100",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin",
+        },
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_manual_config_flow_host_url_with_scheme(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovery_no_devices: AsyncMock,
+    mock_client_success: MagicMock,
+) -> None:
+    """Test manual config flow accepts host with http scheme."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # No devices found, goes directly to manual entry
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "http://192.168.1.100",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin",
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_manual_config_flow_host_hostname(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovery_no_devices: AsyncMock,
+    mock_client_success: MagicMock,
+) -> None:
+    """Test manual config flow accepts hostname."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # No devices found, goes directly to manual entry
+    assert result["step_id"] == "manual"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "zowiebox.local",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin",
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_manual_config_flow_device_info_fallback(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovery_no_devices: AsyncMock,
+) -> None:
+    """Test manual config flow falls back to host-based ID when device info unavailable."""
+    from custom_components.zowietek.exceptions import ZowietekApiError
+
+    with patch(
+        "custom_components.zowietek.config_flow.ZowietekClient",
+        autospec=True,
+    ) as mock_client_class:
+        client = mock_client_class.return_value
+        client.host = "http://192.168.1.100"
+        client.async_test_connection = AsyncMock(return_value=True)
+        client.async_validate_credentials = AsyncMock(return_value=True)
+        client.async_get_sys_attr_info = AsyncMock(
+            side_effect=ZowietekApiError("Invalid parameters", "00003")
+        )
+        client.close = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        # No devices found, goes directly to manual entry
+        assert result["step_id"] == "manual"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "admin",
+            },
+        )
+
+        assert result["type"] is FlowResultType.CREATE_ENTRY
+        assert result["title"] == "ZowieBox"
+        assert result["result"].unique_id == "http://192.168.1.100"
+
+
+async def test_manual_config_flow_general_api_error(
+    hass: HomeAssistant,
+    mock_discovery_no_devices: AsyncMock,
+) -> None:
+    """Test manual config flow handles general ZowietekError."""
+    from custom_components.zowietek.exceptions import ZowietekError
+
+    with patch(
+        "custom_components.zowietek.config_flow.ZowietekClient",
+        autospec=True,
+    ) as mock_client_class:
+        client = mock_client_class.return_value
+        client.async_test_connection = AsyncMock(side_effect=ZowietekError("General API error"))
+        client.close = AsyncMock()
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_USER},
+        )
+
+        # No devices found, goes directly to manual entry
+        assert result["step_id"] == "manual"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: "192.168.1.100",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "admin",
+            },
+        )
+
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "manual"
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+# =============================================================================
+# Credentials Flow Tests (for discovered devices)
+# =============================================================================
+
+
+async def test_credentials_flow_success(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_discovery_one_device: AsyncMock,
+    mock_client_success: MagicMock,
+) -> None:
+    """Test successful credentials flow for discovered device creates entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+
+    # Select the discovered device
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"device": "ZBOX-ABC123"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+    # Submit credentials
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin",
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ZowieBox-Office"
+    assert result["data"][CONF_HOST] == "http://192.168.1.100:80"
+    assert result["data"][CONF_USERNAME] == "admin"
+    assert result["data"][CONF_PASSWORD] == "admin"
+    assert result["result"].unique_id == "ZBOX-ABC123"
+
+
+async def test_credentials_flow_auth_error(
+    hass: HomeAssistant,
+    mock_discovery_one_device: AsyncMock,
+) -> None:
+    """Test credentials flow handles authentication error."""
     from custom_components.zowietek.exceptions import ZowietekAuthError
 
     with patch(
@@ -160,128 +675,27 @@ async def test_config_flow_auth_error(
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
+            {"device": "ZBOX-ABC123"},
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {
-                CONF_HOST: "192.168.1.100",
                 CONF_USERNAME: "admin",
                 CONF_PASSWORD: "wrong_password",
             },
         )
 
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "credentials"
         assert result["errors"] == {"base": "invalid_auth"}
 
 
-async def test_config_flow_timeout_error(
+async def test_credentials_flow_connection_error(
     hass: HomeAssistant,
+    mock_discovery_one_device: AsyncMock,
 ) -> None:
-    """Test config flow handles timeout error."""
-    from custom_components.zowietek.exceptions import ZowietekTimeoutError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.async_test_connection = AsyncMock(
-            side_effect=ZowietekTimeoutError("Timeout after 10s")
-        )
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "192.168.1.100",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_config_flow_unknown_error(
-    hass: HomeAssistant,
-) -> None:
-    """Test config flow handles unknown error."""
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.async_test_connection = AsyncMock(side_effect=RuntimeError("Unknown"))
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "192.168.1.100",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "unknown"}
-
-
-async def test_config_flow_duplicate_device(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_client_success: MagicMock,
-) -> None:
-    """Test config flow aborts if device already configured."""
-    # First, create an existing entry with the same unique_id
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-    existing_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="ZBOX-ABC123",
-        data={
-            CONF_HOST: "192.168.1.50",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "admin",
-        },
-    )
-    existing_entry.add_to_hass(hass)
-
-    # Now try to configure the same device
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-    )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {
-            CONF_HOST: "192.168.1.100",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "admin",
-        },
-    )
-
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-
-async def test_config_flow_form_redisplay_on_error(
-    hass: HomeAssistant,
-) -> None:
-    """Test that form is redisplayed with user's input after error."""
+    """Test credentials flow handles connection error."""
     from custom_components.zowietek.exceptions import ZowietekConnectionError
 
     with patch(
@@ -303,25 +717,42 @@ async def test_config_flow_form_redisplay_on_error(
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
+            {"device": "ZBOX-ABC123"},
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {
-                CONF_HOST: "my-zowiebox.local",
-                CONF_USERNAME: "myuser",
-                CONF_PASSWORD: "mypass",
+                CONF_USERNAME: "admin",
+                CONF_PASSWORD: "admin",
             },
         )
 
         assert result["type"] is FlowResultType.FORM
-        assert result["step_id"] == "user"
+        assert result["step_id"] == "credentials"
         assert result["errors"] == {"base": "cannot_connect"}
-        # Form should still have the schema for re-entry
 
 
-async def test_config_flow_host_url_with_scheme(
+async def test_credentials_flow_duplicate_device(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,
+    mock_discovery_one_device: AsyncMock,
     mock_client_success: MagicMock,
 ) -> None:
-    """Test config flow accepts host with http scheme."""
+    """Test credentials flow aborts if device already configured."""
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    existing_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="ZBOX-ABC123",
+        data={
+            CONF_HOST: "192.168.1.50",
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "admin",
+        },
+    )
+    existing_entry.add_to_hass(hass)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
         context={"source": SOURCE_USER},
@@ -329,284 +760,19 @@ async def test_config_flow_host_url_with_scheme(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        {
-            CONF_HOST: "http://192.168.1.100",
-            CONF_USERNAME: "admin",
-            CONF_PASSWORD: "admin",
-        },
-    )
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-
-
-async def test_config_flow_host_hostname(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-    mock_client_success: MagicMock,
-) -> None:
-    """Test config flow accepts hostname."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
+        {"device": "ZBOX-ABC123"},
     )
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            CONF_HOST: "zowiebox.local",
             CONF_USERNAME: "admin",
             CONF_PASSWORD: "admin",
         },
     )
 
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-
-
-async def test_config_flow_device_info_fallback(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test config flow falls back to host-based ID when device info unavailable."""
-    from custom_components.zowietek.exceptions import ZowietekApiError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.host = "http://192.168.1.100"
-        client.async_test_connection = AsyncMock(return_value=True)
-        client.async_validate_credentials = AsyncMock(return_value=True)
-        # Sys attr endpoint not supported - should fall back gracefully (#49)
-        client.async_get_sys_attr_info = AsyncMock(
-            side_effect=ZowietekApiError("Invalid parameters", "00003")
-        )
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "192.168.1.100",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        # Should succeed with host-based unique_id
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == "ZowieBox"
-        assert result["result"].unique_id == "http://192.168.1.100"
-
-
-async def test_config_flow_sys_attr_fallback_with_hostname(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test config flow derives name from hostname when sys attr unavailable."""
-    from custom_components.zowietek.exceptions import ZowietekApiError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.host = "http://zow001.example.com"
-        client.async_test_connection = AsyncMock(return_value=True)
-        client.async_validate_credentials = AsyncMock(return_value=True)
-        # Sys attr endpoint not supported - should fall back gracefully (#49)
-        client.async_get_sys_attr_info = AsyncMock(
-            side_effect=ZowietekApiError("Invalid parameters", "00003")
-        )
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "zow001.example.com",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        # Should succeed with hostname-derived name
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == "ZowieBox (zow001)"
-        assert result["result"].unique_id == "http://zow001.example.com"
-
-
-async def test_config_flow_general_api_error(
-    hass: HomeAssistant,
-) -> None:
-    """Test config flow handles general ZowietekError."""
-    from custom_components.zowietek.exceptions import ZowietekError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.async_test_connection = AsyncMock(side_effect=ZowietekError("General API error"))
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "192.168.1.100",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        assert result["type"] is FlowResultType.FORM
-        assert result["errors"] == {"base": "cannot_connect"}
-
-
-async def test_config_flow_host_with_scheme_and_port(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test config flow with host that has scheme and port."""
-    from custom_components.zowietek.exceptions import ZowietekApiError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.host = "http://192.168.1.100:8080"
-        client.async_test_connection = AsyncMock(return_value=True)
-        client.async_validate_credentials = AsyncMock(return_value=True)
-        # Sys attr unavailable - tests _derive_name_from_host (#49)
-        client.async_get_sys_attr_info = AsyncMock(
-            side_effect=ZowietekApiError("Invalid parameters", "00003")
-        )
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "http://192.168.1.100:8080",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        # Port is stripped, IP returns "ZowieBox"
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == "ZowieBox"
-
-
-async def test_config_flow_host_with_port_and_subdomain(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test config flow with host with port and subdomain."""
-    from custom_components.zowietek.exceptions import ZowietekApiError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        client.host = "http://zow001.local:8080"
-        client.async_test_connection = AsyncMock(return_value=True)
-        client.async_validate_credentials = AsyncMock(return_value=True)
-        # Sys attr unavailable - tests _derive_name_from_host (#49)
-        client.async_get_sys_attr_info = AsyncMock(
-            side_effect=ZowietekApiError("Invalid parameters", "00003")
-        )
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "http://zow001.local:8080",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        # Port stripped, hostname derived
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == "ZowieBox (zow001)"
-
-
-async def test_config_flow_empty_hostname_fallback(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """Test config flow with edge case where hostname is empty after parsing."""
-    from custom_components.zowietek.exceptions import ZowietekApiError
-
-    with patch(
-        "custom_components.zowietek.config_flow.ZowietekClient",
-        autospec=True,
-    ) as mock_client_class:
-        client = mock_client_class.return_value
-        # Edge case: just dots after scheme/port stripping
-        client.host = "http://....:8080"
-        client.async_test_connection = AsyncMock(return_value=True)
-        client.async_validate_credentials = AsyncMock(return_value=True)
-        # Sys attr unavailable - tests _derive_name_from_host fallback (#49)
-        client.async_get_sys_attr_info = AsyncMock(
-            side_effect=ZowietekApiError("Invalid parameters", "00003")
-        )
-        client.close = AsyncMock()
-        client.__aenter__ = AsyncMock(return_value=client)
-        client.__aexit__ = AsyncMock(return_value=None)
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_USER},
-        )
-
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                CONF_HOST: "....:8080",
-                CONF_USERNAME: "admin",
-                CONF_PASSWORD: "admin",
-            },
-        )
-
-        # Should fall back to "ZowieBox"
-        assert result["type"] is FlowResultType.CREATE_ENTRY
-        assert result["title"] == "ZowieBox"
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 # =============================================================================

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,538 @@
+"""Tests for Zowietek device discovery module."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.zowietek.discovery import (
+    DISCOVERY_PORT,
+    MULTICAST_GROUP,
+    DiscoveredDevice,
+    ZowietekDiscovery,
+    async_discover_devices,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+# Test constants matching the protocol specification
+EXPECTED_MULTICAST_GROUP = "224.170.1.242"
+EXPECTED_DISCOVERY_PORT = 21007
+
+
+class TestDiscoveryConstants:
+    """Test discovery protocol constants."""
+
+    def test_multicast_group_address(self) -> None:
+        """Test multicast group address is correct."""
+        assert MULTICAST_GROUP == EXPECTED_MULTICAST_GROUP
+
+    def test_discovery_port(self) -> None:
+        """Test discovery port is correct."""
+        assert DISCOVERY_PORT == EXPECTED_DISCOVERY_PORT
+
+
+class TestDiscoveredDevice:
+    """Test DiscoveredDevice data class."""
+
+    def test_create_discovered_device(self) -> None:
+        """Test creating a DiscoveredDevice instance."""
+        device = DiscoveredDevice(
+            ip="10.61.22.241",
+            web_port=80,
+            device_sn="27117",
+            device_name="ZowieBox-27117",
+            product_id=2,
+            workmode_id=1,
+        )
+        assert device.ip == "10.61.22.241"
+        assert device.web_port == 80
+        assert device.device_sn == "27117"
+        assert device.device_name == "ZowieBox-27117"
+        assert device.product_id == 2
+        assert device.workmode_id == 1
+
+    def test_discovered_device_from_dict(self) -> None:
+        """Test creating DiscoveredDevice from API response dict."""
+        data = {
+            "ip": "10.61.22.243",
+            "web_port": 80,
+            "device_sn": "25859",
+            "device_name": "ZowieBox-25859",
+            "product_id": 2,
+            "workmode_id": 1,
+        }
+        device = DiscoveredDevice.from_dict(data)
+        assert device.ip == "10.61.22.243"
+        assert device.web_port == 80
+        assert device.device_sn == "25859"
+        assert device.device_name == "ZowieBox-25859"
+
+    def test_discovered_device_from_dict_missing_optional_fields(self) -> None:
+        """Test creating DiscoveredDevice with missing optional fields."""
+        data = {
+            "ip": "192.168.1.100",
+            "web_port": 80,
+            "device_sn": "12345",
+            "device_name": "ZowieBox-12345",
+        }
+        device = DiscoveredDevice.from_dict(data)
+        assert device.ip == "192.168.1.100"
+        assert device.product_id == 0  # default
+        assert device.workmode_id == 0  # default
+
+    def test_discovered_device_host_property(self) -> None:
+        """Test the host property returns correct URL format."""
+        device = DiscoveredDevice(
+            ip="192.168.1.100",
+            web_port=80,
+            device_sn="12345",
+            device_name="Test",
+            product_id=2,
+            workmode_id=1,
+        )
+        assert device.host == "http://192.168.1.100:80"
+
+    def test_discovered_device_host_property_non_standard_port(self) -> None:
+        """Test host property with non-standard port."""
+        device = DiscoveredDevice(
+            ip="192.168.1.100",
+            web_port=8080,
+            device_sn="12345",
+            device_name="Test",
+            product_id=2,
+            workmode_id=1,
+        )
+        assert device.host == "http://192.168.1.100:8080"
+
+
+class TestZowietekDiscovery:
+    """Test ZowietekDiscovery class."""
+
+    def test_create_discovery_instance(self) -> None:
+        """Test creating a ZowietekDiscovery instance."""
+        discovery = ZowietekDiscovery()
+        assert discovery is not None
+        assert discovery.timeout == 3.0  # default timeout
+
+    def test_create_discovery_with_custom_timeout(self) -> None:
+        """Test creating ZowietekDiscovery with custom timeout."""
+        discovery = ZowietekDiscovery(timeout=5.0)
+        assert discovery.timeout == 5.0
+
+    def test_build_discovery_request(self) -> None:
+        """Test building the discovery request message."""
+        discovery = ZowietekDiscovery()
+        request = discovery._build_discovery_request()
+
+        # Parse the request as JSON
+        data = json.loads(request.decode("utf-8"))
+
+        assert data["opt"] == "check_devices_request"
+        assert "master_device_sn" in data
+
+    def test_parse_discovery_response_valid(self) -> None:
+        """Test parsing a valid discovery response."""
+        discovery = ZowietekDiscovery()
+        response = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+                "data": {
+                    "ip": "10.61.22.241",
+                    "web_port": 80,
+                    "device_sn": "27117",
+                    "device_name": "ZowieBox-27117",
+                    "product_id": 2,
+                    "workmode_id": 1,
+                },
+            }
+        ).encode("utf-8")
+
+        device = discovery._parse_response(response)
+        assert device is not None
+        assert device.ip == "10.61.22.241"
+        assert device.device_name == "ZowieBox-27117"
+
+    def test_parse_discovery_response_keepalive_ignored(self) -> None:
+        """Test that keepalive messages are ignored."""
+        discovery = ZowietekDiscovery()
+        response = json.dumps(
+            {
+                "opt": "keepalive",
+                "master_device_sn": "25859",
+            }
+        ).encode("utf-8")
+
+        device = discovery._parse_response(response)
+        assert device is None
+
+    def test_parse_discovery_response_invalid_json(self) -> None:
+        """Test parsing invalid JSON returns None."""
+        discovery = ZowietekDiscovery()
+        response = b"not valid json"
+
+        device = discovery._parse_response(response)
+        assert device is None
+
+    def test_parse_discovery_response_missing_data(self) -> None:
+        """Test parsing response without data field returns None."""
+        discovery = ZowietekDiscovery()
+        response = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+            }
+        ).encode("utf-8")
+
+        device = discovery._parse_response(response)
+        assert device is None
+
+
+class TestAsyncDiscovery:
+    """Test async discovery functionality."""
+
+    @pytest.fixture
+    def mock_socket(self) -> Generator[MagicMock]:
+        """Create a mock socket for testing."""
+        with patch("socket.socket") as mock_sock_class:
+            mock_sock = MagicMock()
+            mock_sock_class.return_value = mock_sock
+            # Mark socket as non-blocking (required for asyncio)
+            mock_sock.setblocking = MagicMock()
+            yield mock_sock
+
+    def _create_async_recvfrom_mock(
+        self, responses: list[tuple[bytes, tuple[str, int]] | type[Exception]]
+    ) -> AsyncMock:
+        """Create an async mock for loop.sock_recvfrom.
+
+        Args:
+            responses: List of (data, addr) tuples or exception types.
+
+        Returns:
+            AsyncMock that returns responses in order then raises TimeoutError.
+        """
+        call_count = 0
+
+        async def mock_recvfrom(sock: MagicMock, bufsize: int) -> tuple[bytes, tuple[str, int]]:
+            nonlocal call_count
+            if call_count < len(responses):
+                response = responses[call_count]
+                call_count += 1
+                if isinstance(response, type) and issubclass(response, Exception):
+                    raise response()
+                return response
+            # After all responses, keep raising TimeoutError
+            raise TimeoutError()
+
+        return AsyncMock(side_effect=mock_recvfrom)
+
+    @pytest.mark.asyncio
+    async def test_discover_devices_returns_list(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that discover returns a list of devices."""
+        response_data = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+                "data": {
+                    "ip": "10.61.22.241",
+                    "web_port": 80,
+                    "device_sn": "27117",
+                    "device_name": "ZowieBox-27117",
+                    "product_id": 2,
+                    "workmode_id": 1,
+                },
+            }
+        ).encode("utf-8")
+
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock(
+                [
+                    (response_data, ("10.61.22.241", 21007)),
+                ]
+            ),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.5)
+            devices = await discovery.async_discover()
+
+        assert isinstance(devices, list)
+        assert len(devices) == 1
+        assert devices[0].ip == "10.61.22.241"
+
+    @pytest.mark.asyncio
+    async def test_discover_devices_multiple_responses(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test discovery with multiple device responses."""
+        response1 = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+                "data": {
+                    "ip": "10.61.22.241",
+                    "web_port": 80,
+                    "device_sn": "27117",
+                    "device_name": "ZowieBox-27117",
+                    "product_id": 2,
+                    "workmode_id": 1,
+                },
+            }
+        ).encode("utf-8")
+
+        response2 = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+                "data": {
+                    "ip": "10.61.22.243",
+                    "web_port": 80,
+                    "device_sn": "25859",
+                    "device_name": "ZowieBox-25859",
+                    "product_id": 2,
+                    "workmode_id": 1,
+                },
+            }
+        ).encode("utf-8")
+
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock(
+                [
+                    (response1, ("10.61.22.241", 21007)),
+                    (response2, ("10.61.22.243", 21007)),
+                ]
+            ),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.5)
+            devices = await discovery.async_discover()
+
+        assert len(devices) == 2
+        device_ips = {d.ip for d in devices}
+        assert "10.61.22.241" in device_ips
+        assert "10.61.22.243" in device_ips
+
+    @pytest.mark.asyncio
+    async def test_discover_devices_no_responses(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test discovery with no device responses."""
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock([]),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.2)
+            devices = await discovery.async_discover()
+
+        assert isinstance(devices, list)
+        assert len(devices) == 0
+
+    @pytest.mark.asyncio
+    async def test_discover_devices_filters_duplicates(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that duplicate responses are filtered."""
+        response = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+                "data": {
+                    "ip": "10.61.22.241",
+                    "web_port": 80,
+                    "device_sn": "27117",
+                    "device_name": "ZowieBox-27117",
+                    "product_id": 2,
+                    "workmode_id": 1,
+                },
+            }
+        ).encode("utf-8")
+
+        # Same device responds twice
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock(
+                [
+                    (response, ("10.61.22.241", 21007)),
+                    (response, ("10.61.22.241", 21007)),
+                ]
+            ),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.5)
+            devices = await discovery.async_discover()
+
+        assert len(devices) == 1
+
+    @pytest.mark.asyncio
+    async def test_discover_devices_ignores_keepalive(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that keepalive messages don't create device entries."""
+        keepalive = json.dumps(
+            {
+                "opt": "keepalive",
+                "master_device_sn": "25859",
+            }
+        ).encode("utf-8")
+
+        discovery_response = json.dumps(
+            {
+                "opt": "check_devices_result",
+                "master_device_sn": "00000",
+                "data": {
+                    "ip": "10.61.22.241",
+                    "web_port": 80,
+                    "device_sn": "27117",
+                    "device_name": "ZowieBox-27117",
+                    "product_id": 2,
+                    "workmode_id": 1,
+                },
+            }
+        ).encode("utf-8")
+
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock(
+                [
+                    (keepalive, ("10.61.22.243", 21007)),
+                    (discovery_response, ("10.61.22.241", 21007)),
+                ]
+            ),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.5)
+            devices = await discovery.async_discover()
+
+        assert len(devices) == 1
+        assert devices[0].device_sn == "27117"
+
+    @pytest.mark.asyncio
+    async def test_discover_socket_configuration(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that socket is configured correctly for multicast."""
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock([]),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.2)
+            await discovery.async_discover()
+
+        # Verify socket was configured for multicast
+        mock_socket.setsockopt.assert_any_call(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        mock_socket.setsockopt.assert_any_call(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+
+    @pytest.mark.asyncio
+    async def test_discover_sends_request_to_multicast(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that discovery request is sent to multicast address."""
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock([]),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.2)
+            await discovery.async_discover()
+
+        # Verify sendto was called with multicast address and port
+        mock_socket.sendto.assert_called_once()
+        call_args = mock_socket.sendto.call_args
+        assert call_args[0][1] == (EXPECTED_MULTICAST_GROUP, EXPECTED_DISCOVERY_PORT)
+
+    @pytest.mark.asyncio
+    async def test_discover_closes_socket(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that socket is closed after discovery."""
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            self._create_async_recvfrom_mock([]),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.2)
+            await discovery.async_discover()
+
+        mock_socket.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_discover_closes_socket_on_error(
+        self,
+        mock_socket: MagicMock,
+    ) -> None:
+        """Test that socket is closed even if an error occurs."""
+
+        async def raise_error(sock: MagicMock, bufsize: int) -> tuple[bytes, tuple[str, int]]:
+            raise OSError("Network error")
+
+        with patch.object(
+            asyncio.get_event_loop(),
+            "sock_recvfrom",
+            AsyncMock(side_effect=raise_error),
+        ):
+            discovery = ZowietekDiscovery(timeout=0.2)
+
+            with pytest.raises(OSError):
+                await discovery.async_discover()
+
+        mock_socket.close.assert_called_once()
+
+
+class TestAsyncDiscoverDevicesFunction:
+    """Test the async_discover_devices convenience function."""
+
+    @pytest.mark.asyncio
+    async def test_async_discover_devices_returns_list(self) -> None:
+        """Test async_discover_devices returns list."""
+        with patch.object(
+            ZowietekDiscovery, "async_discover", new_callable=AsyncMock
+        ) as mock_discover:
+            mock_discover.return_value = [
+                DiscoveredDevice(
+                    ip="10.61.22.241",
+                    web_port=80,
+                    device_sn="27117",
+                    device_name="ZowieBox-27117",
+                    product_id=2,
+                    workmode_id=1,
+                )
+            ]
+
+            devices = await async_discover_devices()
+
+            assert len(devices) == 1
+            assert devices[0].ip == "10.61.22.241"
+
+    @pytest.mark.asyncio
+    async def test_async_discover_devices_with_timeout(self) -> None:
+        """Test async_discover_devices passes timeout."""
+        with patch("custom_components.zowietek.discovery.ZowietekDiscovery") as mock_cls:
+            mock_instance = MagicMock()
+            mock_instance.async_discover = AsyncMock(return_value=[])
+            mock_cls.return_value = mock_instance
+
+            await async_discover_devices(timeout=5.0)
+
+            mock_cls.assert_called_once_with(timeout=5.0)

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -115,7 +115,7 @@ class TestConfigFlowStrings:
         assert isinstance(user["description"], str), "description must be a string"
 
     def test_config_step_user_has_data_fields(self, strings_data: dict[str, object]) -> None:
-        """Test that config.step.user has required data fields."""
+        """Test that config.step.user has device picker field."""
         config = strings_data.get("config")
         assert isinstance(config, dict)
         step = config.get("step")
@@ -125,13 +125,12 @@ class TestConfigFlowStrings:
         data = user.get("data")
         assert isinstance(data, dict), "config.step.user.data must exist"
 
-        required_fields = ["host", "username", "password"]
-        for field in required_fields:
-            assert field in data, f"config.step.user.data must have {field}"
-            assert isinstance(data[field], str), f"{field} must be a string"
+        # User step shows device picker
+        assert "device" in data, "config.step.user.data must have device"
+        assert isinstance(data["device"], str), "device must be a string"
 
     def test_config_step_user_has_data_descriptions(self, strings_data: dict[str, object]) -> None:
-        """Test that config.step.user has data_description for host."""
+        """Test that config.step.user has data_description for device."""
         config = strings_data.get("config")
         assert isinstance(config, dict)
         step = config.get("step")
@@ -140,7 +139,52 @@ class TestConfigFlowStrings:
         assert isinstance(user, dict)
         data_desc = user.get("data_description")
         assert isinstance(data_desc, dict), "config.step.user.data_description must exist"
+        assert "device" in data_desc, "data_description must have device"
+
+    def test_config_step_manual_has_data_fields(self, strings_data: dict[str, object]) -> None:
+        """Test that config.step.manual has required data fields."""
+        config = strings_data.get("config")
+        assert isinstance(config, dict)
+        step = config.get("step")
+        assert isinstance(step, dict)
+        manual = step.get("manual")
+        assert isinstance(manual, dict), "config.step.manual must exist"
+        data = manual.get("data")
+        assert isinstance(data, dict), "config.step.manual.data must exist"
+
+        required_fields = ["host", "username", "password"]
+        for field in required_fields:
+            assert field in data, f"config.step.manual.data must have {field}"
+            assert isinstance(data[field], str), f"{field} must be a string"
+
+    def test_config_step_manual_has_data_descriptions(
+        self, strings_data: dict[str, object]
+    ) -> None:
+        """Test that config.step.manual has data_description for host."""
+        config = strings_data.get("config")
+        assert isinstance(config, dict)
+        step = config.get("step")
+        assert isinstance(step, dict)
+        manual = step.get("manual")
+        assert isinstance(manual, dict)
+        data_desc = manual.get("data_description")
+        assert isinstance(data_desc, dict), "config.step.manual.data_description must exist"
         assert "host" in data_desc, "data_description must have host"
+
+    def test_config_step_credentials_exists(self, strings_data: dict[str, object]) -> None:
+        """Test that config.step.credentials section exists for discovered devices."""
+        config = strings_data.get("config")
+        assert isinstance(config, dict)
+        step = config.get("step")
+        assert isinstance(step, dict)
+        credentials = step.get("credentials")
+        assert isinstance(credentials, dict), "config.step.credentials must exist"
+        assert "title" in credentials, "credentials must have title"
+        assert "description" in credentials, "credentials must have description"
+        data = credentials.get("data")
+        assert isinstance(data, dict), "credentials.data must exist"
+        assert "username" in data, "credentials.data must have username"
+        assert "password" in data, "credentials.data must have password"
 
     def test_config_errors_exist(self, strings_data: dict[str, object]) -> None:
         """Test that config.error section exists with required errors."""


### PR DESCRIPTION
## Summary

Implements ZowieBox device discovery using the proprietary UDP multicast protocol discovered through packet capture analysis. Fixes #12.

### Discovery Protocol

After investigating SSDP and mDNS (both of which the ZowieBox does NOT support), packet capture analysis revealed a proprietary UDP multicast discovery mechanism:

- **Multicast Address:** `224.170.1.242`
- **Port:** `21007`
- **Protocol:** JSON over UDP (IPv4 only)
- **Message Types:** `check_devices_request`, `check_devices_result`, `keepalive`

### Changes

- **New `discovery.py` module** with:
  - `DiscoveredDevice` dataclass for discovered device info
  - `ZowietekDiscovery` class implementing async UDP multicast discovery
  - `async_discover_devices()` convenience function

- **Updated `config_flow.py`** with:
  - Device picker step showing discovered devices
  - Manual entry fallback when no devices found
  - Credentials step for discovered devices
  - Uses discovered serial number as `unique_id`

- **Updated `docs/api.md`** with complete discovery protocol documentation (Section 30)

- **New `tests/test_discovery.py`** with 25 comprehensive unit tests

- **Updated `tests/test_config_flow.py`** with tests for new discovery-based flow

### Config Flow Behavior

1. On startup, performs UDP multicast discovery (3 second timeout)
2. If devices found: Shows device picker with "Enter Manually..." option
3. If no devices found: Goes directly to manual entry form
4. For discovered devices: Prompts only for credentials (host/port known)
5. For manual entry: Prompts for host, username, and password

## Test Plan

- [x] All 539 unit tests pass
- [x] mypy strict type checking passes
- [x] ruff linting passes
- [x] Pre-commit hooks pass
- [x] Live tested API connectivity against devices from environment
- [x] Simulated config flow with real device credentials
- [x] Discovery gracefully handles unreachable multicast network

### Live Testing Results

- **Device 1:** Connection OK, Authentication OK, Device info retrieved (SN: REDACTED)
- **Device 2:** Connection OK, Authentication OK, Device info retrieved (SN: REDACTED)
- **Discovery:** Returns empty list when multicast network unreachable (graceful degradation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)