### PR TITLE
feat(media_player): Add go2rtc stream conversion for non-RTSP URLs (#61)

### DIFF
--- a/custom_components/zowietek/media_player.py
+++ b/custom_components/zowietek/media_player.py
@@ -378,13 +378,11 @@ class ZowietekMediaPlayer(ZowietekEntity, MediaPlayerEntity):
         if any(url_lower.startswith(proto) for proto in NATIVE_PROTOCOLS):
             return False
 
-        # HTTP/HTTPS URLs need evaluation
+        # HTTP/HTTPS URLs always need conversion
+        # ZowieBox only natively supports RTSP, RTMP, and SRT protocols
+        # All HTTP-based streams (HLS, DASH, TS, plain HTTP) require go2rtc
         if url_lower.startswith(("http://", "https://")):
-            # HLS/DASH manifests need conversion
-            if any(url_lower.endswith(ext) for ext in STREAMING_MANIFEST_EXTENSIONS):
-                return True
-            # Plain HTTP streams - ZowieBox can handle directly
-            return False
+            return True
 
         # Unknown protocol - try conversion if go2rtc available
         return True

--- a/tests/test_media_player.py
+++ b/tests/test_media_player.py
@@ -1803,13 +1803,13 @@ class TestMediaPlayerGo2rtcConversion:
 
         assert media_player._needs_go2rtc_conversion("camera.front_door") is True
 
-    async def test_needs_go2rtc_conversion_returns_false_for_plain_http(
+    async def test_needs_go2rtc_conversion_returns_true_for_plain_http(
         self,
         hass: HomeAssistant,
         mock_config_entry: MockConfigEntry,
         mock_zowietek_client: MagicMock,
     ) -> None:
-        """Test plain HTTP URLs do not need conversion."""
+        """Test plain HTTP URLs need conversion (ZowieBox doesn't support HTTP)."""
         from custom_components.zowietek.media_player import ZowietekMediaPlayer
 
         await _setup_integration(hass, mock_config_entry)
@@ -1817,9 +1817,10 @@ class TestMediaPlayerGo2rtcConversion:
         coordinator = mock_config_entry.runtime_data
         media_player = ZowietekMediaPlayer(coordinator)
 
-        # HTTP without HLS/DASH extension
-        assert media_player._needs_go2rtc_conversion("http://example.com/stream") is False
-        assert media_player._needs_go2rtc_conversion("https://example.com/video.mp4") is False
+        # All HTTP/HTTPS URLs need conversion since ZowieBox only supports RTSP/RTMP/SRT
+        assert media_player._needs_go2rtc_conversion("http://example.com/stream") is True
+        assert media_player._needs_go2rtc_conversion("https://example.com/video.mp4") is True
+        assert media_player._needs_go2rtc_conversion("http://tv.example.com/ts/stream/123") is True
 
     async def test_play_media_with_camera_entity_type(
         self,


### PR DESCRIPTION
## Summary

Add go2rtc integration to convert incompatible stream formats (HLS, DASH, HTTP TS, camera entities) to RTSP before sending them to the ZowieBox device. This enables playback of streams that would otherwise be unsupported.

### Features
- **Auto-enable go2rtc** when available in Home Assistant
- **Options flow toggle** to disable go2rtc for troubleshooting
- **Camera entity support** via `media_type="camera"` or `camera.*` media_id
- **HTTP stream conversion** - all HTTP/HTTPS URLs (HLS, DASH, TS, plain HTTP) are converted to RTSP
- **TTL-based cleanup** (5 min) for temporary go2rtc streams
- **Stream caching** to avoid duplicate conversions
- **IPv6 support** - proper URL formatting for IPv6 addresses
- **Proper streamplay lifecycle** - handles source cycling (OFF/ON) for active sources

### Implementation
- New `go2rtc_helper.py` module with `Go2rtcHelper` class
- Updated `media_player.py` with `_needs_go2rtc_conversion()` method
- Added `CONF_USE_GO2RTC` option to config flow
- Initialize/cleanup go2rtc helper in `__init__.py`

### Testing
- 55 new tests for go2rtc functionality
- 100% test coverage maintained (726 tests passing)
- Live device testing confirmed HTTP TS streams work via go2rtc conversion

## Test plan
- [x] Unit tests pass (726 tests, 100% coverage)
- [x] Live device testing with HTTP TS stream URL
- [x] go2rtc stream created successfully
- [x] Stream conversion logged correctly
- [ ] Verify ZowieBox can access go2rtc RTSP stream (requires port forwarding)

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)